### PR TITLE
Added the possibility of passing custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Usage of goad:
       request timeout in seconds (default 15)
   -u string
       URL to load test (required)
+  -H string
+      HTTP Header to add to the request. This option can be set multiple times.
 
 # For example:
 $ goad -n 1000 -c 5 -u https://example.com

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gophergala2016/goad"
 	"github.com/gophergala2016/goad/Godeps/_workspace/src/github.com/dustin/go-humanize"
 	"github.com/gophergala2016/goad/Godeps/_workspace/src/github.com/nsf/termbox-go"
+	"github.com/gophergala2016/goad/helpers"
 	"github.com/gophergala2016/goad/queue"
 )
 
@@ -25,6 +26,7 @@ var (
 	regions     string
 	method      string
 	body        string
+	headers     helpers.StringsliceFlag
 )
 
 const coldef = termbox.ColorDefault
@@ -38,6 +40,7 @@ func main() {
 	flag.UintVar(&requests, "n", 1000, "number of total requests to make")
 	flag.UintVar(&timeout, "t", 15, "request timeout in seconds")
 	flag.StringVar(&regions, "r", "us-east-1,eu-west-1,ap-northeast-1", "AWS regions to run in (comma separated, no spaces)")
+	flag.Var(&headers, "H", "List of headers")
 	flag.Parse()
 
 	if url == "" {
@@ -53,6 +56,7 @@ func main() {
 		Regions:        strings.Split(regions, ","),
 		Method:         method,
 		Body:           body,
+		Headers:        headers,
 	})
 	if testerr != nil {
 		fmt.Println(testerr)

--- a/helpers/stringsliceflag.go
+++ b/helpers/stringsliceflag.go
@@ -1,0 +1,16 @@
+package helpers
+
+import "fmt"
+
+// StringsliceFlag allows you to pass a flag more than one time
+type StringsliceFlag []string
+
+func (s *StringsliceFlag) String() string {
+	return fmt.Sprintf("%s", *s)
+}
+
+// Set appends each instance of the flag passed
+func (s *StringsliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}


### PR DESCRIPTION
Using the `-H` command line switch

-  had to refactor the lamdba.go to use flags instead of os.Args[], to simplify the identification of the arguments being passed and to make it easier to pass multiple times the same flag