### PR TITLE
Version lambda functions

### DIFF
--- a/goad.go
+++ b/goad.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/goadapp/goad/infrastructure"
 	"github.com/goadapp/goad/queue"
+	"github.com/goadapp/goad/version"
 )
 
 // TestConfig type
@@ -137,7 +138,7 @@ func (t *Test) invokeLambda(awsConfig *aws.Config, args invokeArgs) {
 	j, _ := json.Marshal(args)
 
 	svc.InvokeAsync(&lambda.InvokeAsyncInput{
-		FunctionName: aws.String("goad"),
+		FunctionName: aws.String("goad:" + version.LambdaVersion()),
 		InvokeArgs:   bytes.NewReader(j),
 	})
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,12 @@
+package version
+
+import "strings"
+
+// Version describes the Goad version.
+const Version = "1.1.0.pre"
+
+// LambdaVersion returns a version string that can be used as a Lambda function
+// alias.
+func LambdaVersion() string {
+	return "v" + strings.Replace(Version, ".", "-", -1)
+}


### PR DESCRIPTION
So that new goad releases update the lambda code and invoke the correct
version. Using multiple versions of goad is also supported.