### PR TITLE
Use a different flag parser for “nicer” flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ Goad will read your credentials from `~/.aws/credentials` or from the `AWS_ACCES
 $ goad --help
 usage: goad --url=URL [<flags>]
 
-A command-line chat application.
+An AWS Lambda powered load testing tool
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
   -u, --url=URL                  URL to load test
   -m, --method="GET"             HTTP method
   -b, --body=BODY                HTTP request body
@@ -76,8 +77,10 @@ Flags:
   -n, --requests=10              Total number of requests to make
   -t, --timeout=15               Request timeout in seconds
   -r, --regions="us-east-1,eu-west-1,ap-northeast-1"
-                                 AWS regions to run in (comma separated, no spaces)
+                                 AWS regions to run in (comma separated, no
+                                 spaces)
   -p, --aws-profile=AWS-PROFILE  AWS named profile to use
+  -o, --output-file=OUTPUT-FILE  Optional path to JSON file for result storage
   -H, --headers=HEADERS ...      List of headers
       --version                  Show application version.
 

--- a/README.md
+++ b/README.md
@@ -62,22 +62,24 @@ Goad will read your credentials from `~/.aws/credentials` or from the `AWS_ACCES
 
 ```sh
 # Get help:
-$ goad -h
-Usage of goad:
-  -c uint
-      number of concurrent requests (default 10)
-  -m string
-      HTTP method (default "GET")
-  -n uint
-      number of total requests to make (default 1000)
-  -r string
-      AWS regions to run in (comma separated, no spaces) (default "us-east-1")
-  -t uint
-      request timeout in seconds (default 15)
-  -u string
-      URL to load test (required)
-  -H string
-      HTTP Header to add to the request. This option can be set multiple times.
+$ goad --help
+usage: goad --url=URL [<flags>]
+
+A command-line chat application.
+
+Flags:
+  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -u, --url=URL                  URL to load test
+  -m, --method="GET"             HTTP method
+  -b, --body=BODY                HTTP request body
+  -c, --concurrency=10           Number of concurrent requests
+  -n, --requests=10              Total number of requests to make
+  -t, --timeout=15               Request timeout in seconds
+  -r, --regions="us-east-1,eu-west-1,ap-northeast-1"
+                                 AWS regions to run in (comma separated, no spaces)
+  -p, --aws-profile=AWS-PROFILE  AWS named profile to use
+  -H, --headers=HEADERS ...      List of headers
+      --version                  Show application version.
 
 # For example:
 $ goad -n 1000 -c 5 -u https://example.com

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	app         = kingpin.New("goad", "A command-line chat application.")
+	app         = kingpin.New("goad", "An AWS Lambda powered load testing tool")
 	url         string
 	concurrency uint
 	requests    uint

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/dustin/go-humanize"
 	"github.com/goadapp/goad"
@@ -20,6 +21,7 @@ import (
 )
 
 var (
+	app         = kingpin.New("goad", "A command-line chat application.")
 	url         string
 	concurrency uint
 	requests    uint
@@ -34,30 +36,24 @@ var (
 const coldef = termbox.ColorDefault
 const nano = 1000000000
 
+func init() {
+	app.HelpFlag.Short('h')
+
+	url = *app.Flag("url", "URL to load test").Short('u').Required().String()
+	method = *app.Flag("method", "HTTP method").Short('m').Default("GET").String()
+	body = *app.Flag("body", "HTTP request body").Short('b').String()
+	concurrency = *app.Flag("concurrency", "Number of concurrent requests").Short('c').Default("10").Uint()
+	requests = *app.Flag("requests", "Total number of requests to make").Short('n').Default("10").Uint()
+	timeout = *app.Flag("timeout", "Request timeout in seconds").Short('t').Default("15").Uint()
+	regions = *app.Flag("regions", "AWS regions to run in (comma separated, no spaces)").Short('r').Default("us-east-1,eu-west-1,ap-northeast-1").String()
+	awsProfile = *app.Flag("aws-profile", "AWS named profile to use").Short('p').String()
+	app.Flag("headers", "List of headers").Short('H').SetValue(&headers)
+
+	app.Version(version.Version)
+}
+
 func main() {
-	var printVersion bool
-
-	flag.StringVar(&url, "u", "", "URL to load test (required)")
-	flag.StringVar(&method, "m", "GET", "HTTP method")
-	flag.StringVar(&body, "b", "", "HTTP request body")
-	flag.UintVar(&concurrency, "c", 10, "number of concurrent requests")
-	flag.UintVar(&requests, "n", 1000, "number of total requests to make")
-	flag.UintVar(&timeout, "t", 15, "request timeout in seconds")
-	flag.StringVar(&regions, "r", "us-east-1,eu-west-1,ap-northeast-1", "AWS regions to run in (comma separated, no spaces)")
-	flag.StringVar(&awsProfile, "p", "", "AWS named profile to use")
-	flag.Var(&headers, "H", "List of headers")
-	flag.BoolVar(&printVersion, "version", false, "print the current Goad version")
-	flag.Parse()
-
-	if printVersion {
-		fmt.Println(version.Version)
-		os.Exit(0)
-	}
-
-	if url == "" {
-		flag.Usage()
-		os.Exit(0)
-	}
+	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	test, testerr := goad.NewTest(&goad.TestConfig{
 		URL:            url,

--- a/helpers/stringsliceflag.go
+++ b/helpers/stringsliceflag.go
@@ -14,3 +14,8 @@ func (s *StringsliceFlag) Set(value string) error {
 	*s = append(*s, value)
 	return nil
 }
+
+// IsCumulative indicates to Kingpin that the flag is repeatable
+func (s *StringsliceFlag) IsCumulative() bool {
+	return true
+}


### PR DESCRIPTION
Switches to the [Kingpin](https://github.com/alecthomas/kingpin) flag parser so that we can have both long (`--help`) and short ( `-h`) flags.

``` sh
$ goad --help
usage: goad --url=URL [<flags>]

A command-line chat application.

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
  -u, --url=URL                  URL to load test
  -m, --method="GET"             HTTP method
  -b, --body=BODY                HTTP request body
  -c, --concurrency=10           Number of concurrent requests
  -n, --requests=10              Total number of requests to make
  -t, --timeout=15               Request timeout in seconds
  -r, --regions="us-east-1,eu-west-1,ap-northeast-1"
                                 AWS regions to run in (comma separated, no spaces)
  -p, --aws-profile=AWS-PROFILE  AWS named profile to use
  -H, --headers=HEADERS ...      List of headers
      --version                  Show application version.

```
