### PR TITLE
increase limits and number of instances 

### DIFF
--- a/goad.go
+++ b/goad.go
@@ -159,7 +159,11 @@ func numberOfLambdas(concurrency uint, numRegions int) int {
 	if numRegions > int(concurrency) {
 		return int(concurrency)
 	}
-	if concurrency/10 > 100 {
+	if concurrency/300 > 250 { // > 75.000
+		return 500
+	} else if concurrency/100 > 100 { // 10.000 <> 75.000
+		return 300
+	} else if concurrency/10 > 100 { // 1.000 <> 10.000
 		return 100
 	}
 	if int(concurrency) < 10*numRegions {
@@ -181,8 +185,8 @@ func (c TestConfig) check() error {
 	if c.Concurrency < 1 || c.Concurrency > concurrencyLimit {
 		return fmt.Errorf("Invalid concurrency (use 1 - %d)", concurrencyLimit)
 	}
-	if c.TotalRequests < 1 || c.TotalRequests > 1000000 {
-		return errors.New("Invalid total requests (use 1 - 1000000)")
+	if c.TotalRequests < 1 || c.TotalRequests > 2000000 {
+		return errors.New("Invalid total requests (use 1 - 2000000)")
 	}
 	if c.RequestTimeout.Nanoseconds() < nano || c.RequestTimeout.Nanoseconds() > nano*100 {
 		return errors.New("Invalid timeout (1s - 100s)")

--- a/goad.go
+++ b/goad.go
@@ -159,9 +159,9 @@ func numberOfLambdas(concurrency uint, numRegions int) int {
 	if numRegions > int(concurrency) {
 		return int(concurrency)
 	}
-	if concurrency/300 > 250 { // > 75.000
+	if concurrency/200 > 350 { // > 70.000
 		return 500
-	} else if concurrency/100 > 100 { // 10.000 <> 75.000
+	} else if concurrency/100 > 100 { // 10.000 <> 70.000
 		return 300
 	} else if concurrency/10 > 100 { // 1.000 <> 10.000
 		return 100


### PR DESCRIPTION
increase limits and number of instances for better stability on high concurrency loads.

When i increase the number of concurrency requests, lambda start to gave errors, even if the remote server is able to sustain the requests. Increasing the number of instances in the lambda turns the service and requests more stable 

With this change, i can get this:
```
  ./goad  -r eu-central-1,us-east-1,eu-west-1,ap-northeast-1,us-west-2 -c 120000  -n 600000    -u https://test.xxxxxx.com/favicon.ico

   TotReqs   TotBytes    AvgTime   AvgReq/s  AvgKbps/s
    599967     3.3 GB     0.853s  286248.47 1517898.75
   Slowest    Fastest   Timeouts  TotErrors
   14.911s     0.015s          1         27
HTTPStatus   Requests
       200     599940
```
where in the default limit, i get 50% of errors with the same parameters

The increase limit to 2 million is to be able to maintain a test longer for high concurrency tests