### PR TITLE
Set Request.Host if Host header is set

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -27,6 +27,7 @@ var (
 	regions     string
 	method      string
 	body        string
+	hostHeader  string
 	headers     helpers.StringsliceFlag
 	awsProfile  string
 )
@@ -45,6 +46,7 @@ func main() {
 	flag.UintVar(&timeout, "t", 15, "request timeout in seconds")
 	flag.StringVar(&regions, "r", "us-east-1,eu-west-1,ap-northeast-1", "AWS regions to run in (comma separated, no spaces)")
 	flag.StringVar(&awsProfile, "p", "", "AWS named profile to use")
+	flag.StringVar(&hostHeader, "e", "", "Explicit Host header to send with the request")
 	flag.Var(&headers, "H", "List of headers")
 	flag.BoolVar(&printVersion, "version", false, "print the current Goad version")
 	flag.Parse()
@@ -69,6 +71,7 @@ func main() {
 		Body:           body,
 		Headers:        headers,
 		AwsProfile:     awsProfile,
+		HostHeader:     hostHeader,
 	})
 	if testerr != nil {
 		fmt.Println(testerr)

--- a/goad.go
+++ b/goad.go
@@ -31,6 +31,7 @@ type TestConfig struct {
 	Body           string
 	Headers        []string
 	AwsProfile     string
+	HostHeader     string
 }
 
 type invokeArgs struct {
@@ -128,6 +129,11 @@ func (t *Test) invokeLambdas(awsConfig *aws.Config, sqsURL string) {
 			fmt.Sprintf("%s", c.Method),
 			"-b",
 			fmt.Sprintf("%s", c.Body),
+		}
+
+		if c.HostHeader != "" {
+			// args = append([]string{"-e", fmt.Sprintf("%s", c.HostHeader)}, args...)
+			args = append(args, "-e", fmt.Sprintf("%s", c.HostHeader))
 		}
 
 		for _, v := range t.config.Headers {

--- a/lambda/lambda.go
+++ b/lambda/lambda.go
@@ -232,7 +232,11 @@ func fetch(loadTestStartTime time.Time, client *http.Client, address string, req
 		req.Header.Add("Accept-Encoding", "gzip")
 		for _, v := range requestHeaders {
 			header := strings.Split(v, ":")
-			req.Header.Add(strings.Trim(header[0], " "), strings.Trim(header[1], " "))
+			if strings.ToLower(strings.Trim(header[0], " ")) == "host" {
+				req.Host = strings.Trim(header[1], " ")
+			} else {
+				req.Header.Add(strings.Trim(header[0], " "), strings.Trim(header[1], " "))
+			}
 		}
 
 		response, err := client.Do(req)


### PR DESCRIPTION
This fixes #29.

(Context: golang/go#7682)

Another fix would be to add a high level CLI arg which allows explicit setting of the Host header, but almost every other tool in this space (curl, httpie, wrk, siege, etc) honors the behavior of setting a Host header, so this seems like reasonable behavior to support at the UI layer, even if it's not natively managed typically by the Go library. 