### PR TITLE
Added optional json output of results (`-o` flag)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -297,11 +297,11 @@ func saveJsonSummary(path string, result *queue.RegionsAggData) {
 	b, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		return
 	}
 	err = ioutil.WriteFile(path, b, 0644)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		return
 	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -83,7 +83,7 @@ func main() {
 	defer printSummary(&finalResult)
 
 	if outputFile != "" {
-		defer saveJsonSummary(outputFile, &finalResult)
+		defer saveJSONSummary(outputFile, &finalResult)
 	}
 
 	sigChan := make(chan os.Signal, 1)
@@ -281,7 +281,7 @@ func printSummary(result *queue.RegionsAggData) {
 	fmt.Println("")
 }
 
-func saveJsonSummary(path string, result *queue.RegionsAggData) {
+func saveJSONSummary(path string, result *queue.RegionsAggData) {
 	if len(result.Regions) == 0 {
 		return
 	}


### PR DESCRIPTION
I was hoping to interact with goad programatically, so I could do something like (pseudocode)

```
for a range of concurrency levels
    run a goad test
    if the results are sufficiently bad, return
```

This way I can determine the breaking points (timeouts, error codes, under-SLA performance) of various architectures relatively unattended. All that was really needed beyond the basic existing goad plumbing was an easy way of parsing the results. Instead of scraping the output format, it seemed straightforward to add a JSON output option, which could also easily lead to post-run result saving, or charting, or any number of other use cases.

```
# simple use case
$ goad -c 15 -n 50 -u testdomain.com -o results.json
# easily track results over time
$ goad -c 15 -n 50 -u testdomain.com -o ~/testdomain_perf/goad-$(date +"%Y_%m_%d-%H_%m_%S").json                                                                                                   
```