### PR TITLE
Added optional display of elapsed time percentiles

### DIFF
--- a/goad.go
+++ b/goad.go
@@ -31,6 +31,7 @@ type TestConfig struct {
 	Body           string
 	Headers        []string
 	AwsProfile     string
+	ShowPercentiles bool
 }
 
 type invokeArgs struct {
@@ -131,6 +132,9 @@ func (t *Test) invokeLambdas(awsConfig *aws.Config, sqsURL string) {
 			fmt.Sprintf("%s", c.Method),
 			"-b",
 			fmt.Sprintf("%s", c.Body),
+		}
+		if c.ShowPercentiles {
+			args = append(args, "-i", "true")
 		}
 
 		for _, v := range t.config.Headers {

--- a/helpers/int64slice.go
+++ b/helpers/int64slice.go
@@ -1,0 +1,7 @@
+package helpers
+
+type Int64slice []int64
+
+func (a Int64slice) Len() int           { return len(a) }
+func (a Int64slice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a Int64slice) Less(i, j int) bool { return a[i] < a[j] }


### PR DESCRIPTION
Highlights on Issue #12 resolution:

We had to make a decision on how to compute the percentiles, in this case, we opted to match Apache Benchmark scores distribution (50%, 66%, 75%, 80%, 90%, 95%, 99% & 100%) - this can be modified on queue/aggregation.go on line 13 (if you guys want to match exactly as the conversation going on @GitHub)

The Percentile option was added as a paramenter "-i" with false as default. We would liked to use "-p", but it was already in use.

Finally, to calculate the percentile, we took the approach of accumulating the stats to produce partials and final numbers in queue/aggregation.go 

We thought that HDR Histogram will introduce extra complexity (and computational cost, being lambda sensible in regards to runtime).

Now the trade-off of this approach in numbers is 8 bytes per request. For example, you will need to launch 134,217,728 requests to consume 1Gb of memory.