### PR TITLE
Issue#93

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -98,6 +98,7 @@ func start(test *goad.Test, finalResult *queue.RegionsAggData, sigChan chan os.S
 		panic(err)
 	}
 
+	defer test.Clean()
 	defer termbox.Close()
 	termbox.Sync()
 	renderString(0, 0, "Launching on AWS... (be patient)", coldef, coldef)

--- a/queue/aggregation.go
+++ b/queue/aggregation.go
@@ -21,6 +21,7 @@ type AggData struct {
 	Fastest              int64          `json:"fastest"`
 	Region               string         `json:"region"`
 	FatalError           string         `json:"fatal-error"`
+	Finished             bool           `json:"finished"`
 }
 
 // RegionsAggData type
@@ -31,12 +32,16 @@ type RegionsAggData struct {
 
 func (d *RegionsAggData) allRequestsReceived() bool {
 	var requests uint
+	var finishedCount int
 
 	for _, region := range d.Regions {
 		requests += uint(region.TotalReqs)
+		if region.Finished {
+			finishedCount += 1
+		}
 	}
 
-	return requests == d.TotalExpectedRequests
+	return requests == d.TotalExpectedRequests || finishedCount == len(d.Regions)
 }
 
 func addResult(data *AggData, result *AggData, isFinalSum bool) {
@@ -70,6 +75,9 @@ func addResult(data *AggData, result *AggData, isFinalSum bool) {
 	}
 	if result.Fastest > 0 && (data.Fastest == 0 || result.Fastest < data.Fastest) {
 		data.Fastest = result.Fastest
+	}
+	if result.Finished {
+		data.Finished = true
 	}
 }
 


### PR DESCRIPTION
This feature was developed on top of branch issue#27.

It's worth mentioning that to maintain backward compatibility, we are keeping default values. For example, we kept '-n 1000' default value, therefore to generate unlimited traffic over a period of 60 secs, parameters should be '-n 0 -N 60'

Ideally it would be better to just specify '-N 60' and remove the default value of which sets -n to 1000.

We can review this later, if you agree.
