### PR TITLE
Fix sqsadapter name and test

### DIFF
--- a/lambda/lambda.go
+++ b/lambda/lambda.go
@@ -238,7 +238,7 @@ func (l *goadLambda) setupAwsConfig() *aws.Config {
 }
 
 func (l *goadLambda) setupAwsSqsAdapter(config *aws.Config) {
-	l.resultSender = queue.NewSQSAdaptor(config, l.Settings.SqsURL)
+	l.resultSender = queue.NewSQSAdapter(config, l.Settings.SqsURL)
 }
 
 func (l *goadLambda) setupJobQueue(count int) {

--- a/queue/aggregation.go
+++ b/queue/aggregation.go
@@ -104,7 +104,7 @@ func aggregate(results chan RegionsAggData, awsConfig *aws.Config, queueURL stri
 	defer close(results)
 	data := RegionsAggData{make(map[string]AggData), totalExpectedRequests, lambdasByRegion}
 
-	adaptor := NewSQSAdaptor(awsConfig, queueURL)
+	adaptor := NewSQSAdapter(awsConfig, queueURL)
 	timeoutStart := time.Now()
 	for {
 		result := adaptor.Receive()

--- a/queue/sqsadaptor.go
+++ b/queue/sqsadaptor.go
@@ -34,8 +34,8 @@ type DummyAdaptor struct {
 	QueueURL string
 }
 
-// NewSQSAdaptor returns a new sqs adator object
-func NewSQSAdaptor(awsConfig *aws.Config, queueURL string) *SQSAdaptor {
+// NewSQSAdapter returns a new sqs adator object
+func NewSQSAdapter(awsConfig *aws.Config, queueURL string) *SQSAdaptor {
 	return &SQSAdaptor{getClient(awsConfig), queueURL}
 }
 

--- a/queue/sqsadaptor_test.go
+++ b/queue/sqsadaptor_test.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	// "fmt"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,32 +11,33 @@ import (
 func init() {
 }
 
-func TestAdaptorConstruction(t *testing.T) {
+func TestAdapterConstruction(t *testing.T) {
 	config := aws.NewConfig().WithRegion("somewhere")
-	testsqs := NewSQSAdaptor(config, "testqueue")
+	testsqs := NewSQSAdapter(config, "testqueue")
 	assert.Equal(t, testsqs.QueueURL, "testqueue")
 }
 
 func TestJSON(t *testing.T) {
-	// result := AggData{
-	// 	299,
-	// 	234,
-	// 	256,
-	// 	int64(9999),
-	// 	2136,
-	// 	make(map[string]int),
-	// 	int64(12345),
-	// 	float32(6789),
-	// 	float32(6789),
-	// 	int64(4567),
-	// 	int64(4567),
-	// 	"eu-west",
-	// 	"sorry",
-	// }
-	// str, jsonerr := jsonFromResult(result)
-	// if jsonerr != nil {
-	// 	fmt.Println(jsonerr)
-	// 	return
-	// }
-	// assert.Equal(t, str, "{\"total-reqs\":299,\"total-timed-out\":234,\"total-conn-error\":256,\"ave-time-to-first\":9999,\"tot-bytes-read\":2136,\"statuses\":{},\"ave-time-for-req\":12345,\"ave-req-per-sec\":6789,\"ave-kbytes-per-sec\":6789,\"slowest\":4567,\"fastest\":4567,\"region\":\"eu-west\",\"fatal-error\":\"sorry\"}")
+	// This test just verifies the json api.
+	result := AggData{
+		TotalReqs:            299,
+		TotalTimedOut:        234,
+		TotalConnectionError: 256,
+		AveTimeToFirst:       9999,
+		TotBytesRead:         2136,
+		Statuses:             make(map[string]int),
+		AveTimeForReq:        12345,
+		AveReqPerSec:         6789,
+		AveKBytesPerSec:      6789,
+		Slowest:              4567,
+		Fastest:              4567,
+		Region:               "eu-west",
+		FatalError:           "sorry",
+	}
+	str, jsonerr := jsonFromResult(result)
+	if jsonerr != nil {
+		fmt.Println(jsonerr)
+		return
+	}
+	assert.Equal(t, str, "{\"total-reqs\":299,\"total-timed-out\":234,\"total-conn-error\":256,\"ave-time-to-first\":9999,\"tot-bytes-read\":2136,\"statuses\":{},\"ave-time-for-req\":12345,\"ave-req-per-sec\":6789,\"ave-kbytes-per-sec\":6789,\"slowest\":4567,\"fastest\":4567,\"region\":\"eu-west\",\"fatal-error\":\"sorry\",\"finished\":false,\"finished-lambdas\":0}")
 }


### PR DESCRIPTION
The SQS Adapter was misspelled and the unit test was not updated for a changes in the data structure.

The test is actually valuable because is specifies the SQS exchange format between lambda and CLI.