### PR TITLE
update homebrew formula with tag

### DIFF
--- a/HomebrewFormula/goad.rb
+++ b/HomebrewFormula/goad.rb
@@ -1,8 +1,7 @@
 class Goad < Formula
   desc "An AWS Lambda powered, highly distributed, load testing tool built in Go."
   homepage "https://goad.io/"
-  url "https://github.com/goadapp/goad.git"
-  version "1.4.0"
+  url "https://github.com/goadapp/goad.git", :tag => "v1.4.0"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
We are using a tagged version to comply to homebrew-core standards.