### PR TITLE
Update homebrew recipe to be compliant for hombrew-core

### DIFF
--- a/HomebrewFormula/goad.rb
+++ b/HomebrewFormula/goad.rb
@@ -1,17 +1,29 @@
+require "language/go"
+
 class Goad < Formula
   desc "AWS Lambda powered, highly distributed, load testing tool built in Go."
   homepage "https://goad.io/"
-  url "https://github.com/goadapp/goad.git", :tag => "v1.4.0"
+  url "https://github.com/goadapp/goad.git", :tag => "v1.4.1"
 
   depends_on "go" => :build
 
+  go_resource "github.com/jteeuwen/go-bindata" do
+    url "https://github.com/jteeuwen/go-bindata.git",
+        :revision => "a0ff2567cfb70903282db057e799fd826784d41d"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOBIN"] = buildpath/"bin"
+    dir = buildpath/"src/github.com/goadapp/goad"
+    dir.install buildpath.children
     ENV.prepend_create_path "PATH", buildpath/"bin"
+    Language::Go.stage_deps resources, buildpath/"src"
 
-    (buildpath/"src/github.com/goadapp/goad").install buildpath.children
-    cd "src/github.com/goadapp/goad/" do
+    cd "src/github.com/jteeuwen/go-bindata/go-bindata" do
+      system "go", "install"
+    end
+
+    cd dir do
       system "make", "build"
       bin.install "build/goad"
     end

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lambda:
 	@$(ZIP) data/lambda data/lambda
 
 bindata: lambda
-	@go get -u github.com/jteeuwen/go-bindata/...
+	@go get github.com/jteeuwen/go-bindata/...
 	@go-bindata -modtime $(TIMESTAMP) -nocompress -pkg infrastructure -o infrastructure/bindata.go data/lambda.zip
 
 linux: bindata

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOPATH := ${PWD}/vendor:${GOPATH}
 export GOPATH
 
 # These will be provided to the target
-VERSION := 1.4.0
+VERSION := 1.4.1
 BUILD := `git rev-parse HEAD`
 
 # Timestamp of last commit to allow for reproducable builds


### PR DESCRIPTION
To address the second issue in our [Pull Request](https://github.com/Homebrew/homebrew-core/pull/13162) to hombrew-core. I've added a fixed revision of go-bindata to the build process.

Well need to tag the merged release with 1.4.1.