### PR TITLE
Build .deb and .rpm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ go:
   - 1.8
 
 install:
+  - sudo apt install alien
   - go get github.com/jteeuwen/go-bindata/...
 
 script:
   - make test
   - make all-zip
+  - make linux-packages
 
 deploy:
   provider: releases
@@ -24,6 +26,10 @@ deploy:
     - build/zip/goad-osx-x86-64.zip
     - build/zip/goad-windows-x86-64.zip
     - build/zip/goad-windows-x86.zip
+    - build/goad_amd64.deb
+    - build/goad_i386.deb
+    - build/goad.x86_64.rpm
+    - build/goad.i386.rpm
   skip_cleanup: true
   on:
     tags: true

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,0 +1,12 @@
+Package: goad
+Version: {{VERSION}}
+Section: base
+Priority: optional
+Architecture: {{ARCH}}
+Maintainer: {{MAINTAINER}}
+Description: AWS Lambda powered, highly distributed, load testing tool built in Go
+ Goad takes full advantage of the power of Amazon Lambdas for distributed load
+ testing. You can use goad to launch HTTP loads from up to four AWS regions at
+ once. Each lambda can handle hundreds of concurrent connections, we estimate
+ that Goad should be able to achieve peak loads of up to 100,000 concurrent
+ requests.

--- a/DEBIAN/copyrigth
+++ b/DEBIAN/copyrigth
@@ -1,0 +1,25 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/goadapp/goad/
+
+Files: *
+Copyright: 2016 Joao Cardoso, Matias Korhonen, Rasmus Sten, and Stephen Sykes
+License: Expat
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.


### PR DESCRIPTION
This PR addresses #126 by providing new build targets for debian and rpm packages in the Makefile.
The generated packages are fairly minimal containing just the goad binary for the according architecture. Relying on `alien` to generate the rpm packages from the generated deb packages.

The travis-ci build file is slightly modified to output these new build artifacts and to install the required packages for the build process.

The zip files with the build for the linux platform have not yet been removed from the build process.