### PR TITLE
Use git tag when building goad with travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BUILD := `git rev-parse HEAD`
 TIMESTAMP := `git log -1 --date=format:%Y%m%d%H%M --pretty=format:%cd`
 
 # Use linker flags to provide version/build settings to the target
-LDFLAGS = -ldflags "-X=github.com/goadapp/goad/version.version=$(VERSION) -X=github.com/goadapp/goad/version.build=$(BUILD)"
+LDFLAGS = -ldflags "-X=github.com/goadapp/goad/version.version=$(VERSION) -X=github.com/goadapp/goad/version.build=$(BUILD) -X=github.com/goadapp/goad/version.travisTag=$(TRAVIS_TAG)"
 
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")

--- a/version/version.go
+++ b/version/version.go
@@ -4,8 +4,9 @@ import "strings"
 
 // Version describes the Goad version.
 var (
-	version string
-	build   string
+	version   string
+	build     string
+	travisTag string
 )
 
 // Version returns the version
@@ -21,9 +22,16 @@ func Build() string {
 	return build
 }
 
+func ReleaseVersion() string {
+	return travisTag
+}
+
 // String returns a composed string of version and build number
 func String() string {
-	return Version() + "-" + Build()
+	if ReleaseVersion() == "" {
+		return Version() + "-" + Build()
+	}
+	return ReleaseVersion()
 }
 
 // LambdaVersion returns a version string that can be used as a Lambda function


### PR DESCRIPTION
Fixes #151 but needs to be tested on a non release build first to verify if this works as expected.

If the TRAVIS_TAG environment variable is present we use this to set the version reported by the cli.