### PR TITLE
Fix run-docker experimental mode

### DIFF
--- a/infrastructure/docker/docker.go
+++ b/infrastructure/docker/docker.go
@@ -263,8 +263,8 @@ func (i *dockerInfrastructure) Receive(results chan *result.LambdaResults) {
 		case msg := <-msgs:
 			lambdaResult := &api.RunnerResult{}
 			json.Unmarshal(msg.Body, lambdaResult)
-			lambdaAggregate := data.Lambdas[lambdaResult.RunnerID]
-			result.AddResult(&lambdaAggregate, lambdaResult)
+			lambdaAggregate := &data.Lambdas[lambdaResult.RunnerID]
+			result.AddResult(lambdaAggregate, lambdaResult)
 			results <- data
 		}
 		if data.AllLambdasFinished() {


### PR DESCRIPTION
Fix #172

Refactoring of the infrastructure code has left the docker mode in a non working state due to pointer reference errors.