### PR TITLE
Do not use `sh` syntax highlighting for the usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Goad will read your credentials from `~/.aws/credentials` or from the `AWS_ACCES
 
 ### CLI
 
-```sh
+```
 # Get help:
 $ goad --help
 usage: goad [<flags>] [<url>]


### PR DESCRIPTION
Using `sh` here produces odd highlights as with the words `time` and `in` which are distracting and not helpful.