### PR TITLE
fixing node version error

### DIFF
--- a/infrastructure/aws/aws.go
+++ b/infrastructure/aws/aws.go
@@ -184,7 +184,7 @@ func (infra *AwsInfrastructure) createLambdaFunction(svc *lambda.Lambda, roleArn
 		FunctionName: aws.String("goad"),
 		Handler:      aws.String("index.handler"),
 		Role:         aws.String(roleArn),
-		Runtime:      aws.String("nodejs4.3"),
+		Runtime:      aws.String("nodejs8.10"),
 		MemorySize:   aws.Int64(1536),
 		Publish:      aws.Bool(true),
 		Timeout:      aws.Int64(300),


### PR DESCRIPTION
the node 4.3 runtime is no longer available on aws, this PR uses the latest version