### PR TITLE
Clean up SQS resources

### DIFF
--- a/infrastructure/aws/aws.go
+++ b/infrastructure/aws/aws.go
@@ -146,7 +146,7 @@ func (infra *AwsInfrastructure) Setup() (func(), error) {
 	}
 	infra.queueURL = queueURL
 	return func() {
-
+		infra.teardown()
 	}, nil
 }
 


### PR DESCRIPTION
I've noticed that none of the test run SQS queues are ever cleaned up, even after successful execution. It looks like the AWS teardown was never actually being invoked from anywhere.