### PR TITLE
Fix reading and writing of the results at the same time

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -326,6 +326,7 @@ outer:
 			if !ok {
 				break outer
 			}
+			result.Lock()
 			currentResult = *result
 			if firstTime && render {
 				clearLogo()
@@ -341,9 +342,7 @@ outer:
 					y = renderRegion(regionsData[region], y)
 					y++
 				}
-			}
 
-			if render {
 				y = 0
 				var percentDone float64
 				if test.Requests > 0 {
@@ -355,7 +354,7 @@ outer:
 
 				termbox.Flush()
 			}
-
+			result.Unlock()
 		case <-sigChan:
 			break outer
 		}

--- a/infrastructure/aws/aws.go
+++ b/infrastructure/aws/aws.go
@@ -66,7 +66,9 @@ func (infra *AwsInfrastructure) Receive(results chan *result.LambdaResults) {
 		if lambdaResults != nil {
 			for _, lambdaResult := range lambdaResults {
 				lambdaAggregate := &data.Lambdas[lambdaResult.RunnerID]
+				data.Lock()
 				result.AddResult(lambdaAggregate, lambdaResult)
+				data.Unlock()
 				results <- data
 			}
 			if data.AllLambdasFinished() {

--- a/result/result.go
+++ b/result/result.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"sort"
 	"time"
+	"sync"
 
 	"github.com/goadapp/goad/api"
 	"github.com/goadapp/goad/goad/util"
@@ -31,6 +32,7 @@ type AggData struct {
 // LambdaResults type
 type LambdaResults struct {
 	Lambdas []AggData
+	sync.RWMutex
 }
 
 // Regions the LambdaResults were collected from


### PR DESCRIPTION
The current implementation doesn't work with Go1.6+ (probably, atleast 1.8) because `map` is not thread safe. I dont think it ever was but modern versions just detect it better.

This PR wraps the reading of the results for printout and updating of them in mutexes. Tested on Go 1.11

```
Region: us-east-1
   TotReqs   TotBytes    AvgTime    AvgReq/s  (post)unzip
      7270     4.1 MB     0.186s      209.22     116 kB/s
   Slowest    Fastest   Timeouts  TotErrors
    1.042s     0.140s          0       1637fatal error: concurrent map read and map write

goroutine 1 [running]:
runtime.throw(0x175f74f, 0x21)me    AvgReq/s  (post)unzip
      71/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:608 +0x72 fp=0xc0001318d0 sp=0xc0001318a0 pc=0x102c002
runtime.mapaccess1_faststr(0x1667420, 0xc0004193b0, 0xc001f1dd3b, 0x3, 0x0)
    0.95/usr/local/Cellar/go/1.11.4/libexec/src/runtime/map_faststr.go:21 +0x418 fp=0xc000131940 sp=0xc0001318d0 pc=0x10134e8
github.com/goadapp/goad/result.sumAggData(0xc001e00fc0, 0x4, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
Region: /Users/n1ko/Documents/goad/result/result.go:107 +0x109 fp=0xc000131ba8 sp=0xc000131940 pc=0x122aab9
github.com/goadapp/goad/result.(*LambdaResults).RegionsData(0xc000131e70, 0xc000131df0)
      67/Users/n1ko/Documents/goad/result/result.go:53 +0xe9 fp=0xc000131d10 sp=0xc000131ba8 pc=0x122a389
github.com/goadapp/goad/cli.start(0xc0000f6180, 0xc0002b1140, 0x0, 0x0, 0x0)
    1.09/Users/n1ko/Documents/goad/cli/cli.go:337 +0x2f6 fp=0xc000131ee8 sp=0xc000131d10 pc=0x15afc76
github.com/goadapp/goad/cli.Run()
    /Users/n1ko/Documents/goad/cli/cli.go:89 +0x1b8 fp=0xc000131f88 sp=0xc000131ee8 pc=0x15ad678
main.main()
    /Users/n1ko/Documents/goad/main.go:6 +0x20 fp=0xc000131f98 sp=0xc000131f88 pc=0x15b2890
runtime.main()
    /usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:201 +0x207 fp=0xc000131fe0 sp=0xc000131f98 pc=0x102d977
runtime.goexit()
    /usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc000131fe8 sp=0xc000131fe0 pc=0x1059101
```

Snippet of the problem