### PR TITLE
Fix #192 by updating Node JS version

### DIFF
--- a/infrastructure/aws/aws.go
+++ b/infrastructure/aws/aws.go
@@ -184,7 +184,7 @@ func (infra *AwsInfrastructure) createLambdaFunction(svc *lambda.Lambda, roleArn
 		FunctionName: aws.String("goad"),
 		Handler:      aws.String("index.handler"),
 		Role:         aws.String(roleArn),
-		Runtime:      aws.String("nodejs8.10"),
+		Runtime:      aws.String("nodejs12.x"),
 		MemorySize:   aws.Int64(1536),
 		Publish:      aws.Bool(true),
 		Timeout:      aws.Int64(300),


### PR DESCRIPTION
The version of Node currently being used is outdated, resulting in the following AWS error when running Goad:

`InvalidParameterValueException: The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions.`

This PR updates the Node version to 12.x. I built a binary from source on OSX and was successfully able to deploy a Node 12.x Lambda function and run a load test.

<img width="1345" alt="Screen Shot 2020-04-23 at 11 15 23 AM" src="https://user-images.githubusercontent.com/1622358/80134629-dc1eb080-8553-11ea-956f-b2ea6567c42e.png">

```
Regional results

Region: us-east-1
   TotReqs   TotBytes    AvgTime    AvgReq/s  (post)unzip
        20     9.1 kB     2.034s        4.61     2.1 kB/s
   Slowest    Fastest   Timeouts  TotErrors
    4.269s     0.128s          0          0

Overall

   TotReqs   TotBytes    AvgTime    AvgReq/s  (post)unzip
        20     9.1 kB     2.034s        4.61     2.1 kB/s
   Slowest    Fastest   Timeouts  TotErrors
    4.269s     0.128s          0          0
HTTPStatus   Requests
       200         20
```